### PR TITLE
Improve the instructions for composer install in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ also be used with Drupal installed directly on a git clone of core.
 # instructions in its README then skip to step 2.
 ddev config --project-type=drupal11 --docroot=web
 ddev start
-ddev composer create joachim-n/drupal-core-development-project
+ddev composer create-project joachim-n/drupal-core-development-project
 
 # 1B: Install directly on a git clone
 git clone https://git.drupalcode.org/project/drupal.git drupal

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ddev start
 ddev composer install
 
 # 2. Install this add-on
-ddev add-on get justafish/ddev-drupal-core-dev
+ddev add-on get joachim-n/ddev-drupal-core-dev
 
 # 3. Install drupal
 ddev drush si -y --account-pass==admin

--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ also be used with Drupal installed directly on a git clone of core.
 # 1A: Install with Composer project template (recommended)
 # If you already installed a project using the template following the
 # instructions in its README then skip to step 2.
-ddev config --project-type=drupal --php-version=8.3
+ddev config --project-type=drupal11 --docroot=web
 ddev start
 ddev composer create joachim-n/drupal-core-development-project
-ddev config --update
-ddev restart
 
 # 1B: Install directly on a git clone
 git clone https://git.drupalcode.org/project/drupal.git drupal

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ also be used with Drupal installed directly on a git clone of core.
 # 1A: Install with Composer project template (recommended)
 # If you already installed a project using the template following the
 # instructions in its README then skip to step 2.
-ddev config --project-type=drupal11 --docroot=web
+ddev config --project-type=drupal12 --docroot=web
 ddev start
 ddev composer create-project joachim-n/drupal-core-development-project
+ddev composer require drush/drush
 
 # 1B: Install directly on a git clone
 git clone https://git.drupalcode.org/project/drupal.git drupal


### PR DESCRIPTION
At the moment step 1A is using `ddev config --project-type=drupal --php-version=8.3`, the drupal project type is not advised to be used anymore, it is still working as an alias of the latest drupal version but still drupal11 is the preferred way, and the php version is the default for the drupal11 project type anyway. instead it is necessary and advisable to set the docroot to web which is used by your composer template. that way

```
ddev config --update
ddev restart
```
is obsolete as well